### PR TITLE
兼容旧版PyYaml读取配置文件

### DIFF
--- a/utils/translation.py
+++ b/utils/translation.py
@@ -12,7 +12,10 @@ class Translation:
 			if file.endswith(FileSuffix):
 				lang = file.rstrip(FileSuffix)
 				with open(lang_dir + file, encoding='utf8') as f:
-					self.translations[lang] = yaml.load(f, Loader=yaml.FullLoader)
+					try:
+						self.translations[lang] = yaml.load(f, Loader=yaml.FullLoader)
+					except:
+						self.translations[lang] = yaml.load(f, Loader=yaml.Loader)
 
 	@property
 	def languages(self):


### PR DESCRIPTION
错误如图：
![](https://i.loli.net/2020/08/08/cOlCY82JVIhmtwS.png)

---
解决方式：
当yaml.FullLoader出错时采用yaml.Loader方法